### PR TITLE
Include the other copyright holders in the LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 The MIT License
 
-Copyright 2024 Bill Mill
+Copyright © 2024 Bill Mill
+Copyright © 2024 !ZAJC!/GDS
+Portions Copyright © 2005-2020 Rich Felker, et al.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I am 100% sure this was just a result of auto-generating the LICENSE in github, as you very prominently gave credit in your README (thanks!!)

I licensed my other libs as 0BSD so this is not required, but [Rich Felker](https://github.com/richfelker) licensed under MIT, so then I went ahead and did the same for all of uwcwidth code...

Per the MIT license requirements, putting in the copyrights from all the authors. Rich Felker in particular personally implemented the brilliantly elegant sparse bitmap scheme and there's substantial portions of it present in `uwcwidth`, so it also feels incredibly right to update this, even if it were not a requirement :)

See https://fossa.com/blog/open-source-licenses-101-mit-license/

So, what can’t you do with MIT-licensed code? The answer is “not much,” with a few exceptions. For one, you can’t hold the code author(s) legally liable for any reason. You also can’t delete the copyright notice and original license from your version of the code.

Also for example:
https://opensource.stackexchange.com/questions/13178/is-it-legal-to-remove-a-contributors-name-from-the-licence