### PR TITLE
Convert unsigned range compare into signed compares, expand tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,11 +133,12 @@ function _wcwidth(wc) {
     return -1;
   }
 
-  if (wc - 0x20000 < 0x20000) {
+  if (wc >= 0x20000 && wc < 0x40000) {
     return 2;
   }
 
-  if (wc === 0xe0001 || wc - 0xe0020 <= 0x5f || wc - 0xe0100 < 0xef) {
+  if (wc === 0xe0001 || (wc >= 0xe0020 && wc <= 0xe007f)
+      || (wc >= 0xe0100 && wc < 0xe01ef)) {
     return 0;
   }
 

--- a/test.js
+++ b/test.js
@@ -41,6 +41,22 @@ describe("wcwidth", () => {
     // emoji modifiers
     emFitzpatrickType3: ["\u{1f3fc}", 2],
     emFitzpatrickType5: ["\u{1f3fe}", 2],
+    // CJK ideographs are 20000-3ffff
+    qiang: ["\u{2b017}", 2],
+    // TIP, seal script
+    seal_32477: ["\u{32477}", 2],
+    // unassigned codepoints should default to 1,
+    // likely for forward compatibility
+    unassigned_plane_4: ["\u{40000}", 1],
+    unassigned_plane_d: ["\u{d0000}", 1],
+    unassigned_plane_e: ["\u{e0002}", 1],
+    // musl code insists on doing this even in the tags plane for unassigned:
+    // (should we just default to everything in 0xe0000-0xeffff as invisible?)
+    tag_unassigned: ["\u{e0080}", 1],
+    // but assigned codepoints in the tags code block should be invisible
+    tag_begin: ["\u{e0001}", 0],
+    tag_space: ["\u{e0020}", 0],
+    tag_end: ["\u{e007f}", 0]
   };
 
   it("works as expected", () => {


### PR DESCRIPTION
The originating C/Cython code uses an unsigned type and takes advantage of a less-known trick to do a single compare for a range:

```c
int test_between_2_and_7(int x) {
  return (x >= 2 && x <= 7);
}
```

becomes:

```c
int test_between_2_and_7(unsigned int x) {
  return (x - 2) <= (7 - 2)
}
```

if `x == 1`, the expression `1 - 2` will overflow to `UINT_MAX`, which will then return `0`. Indeed, `1` is outside of the range.

The advantage of this approach is that we have a single subtract and compare vs 2 compares and a logical and.

However, in Javascript, we are not using unsigned integers and in general these don't translate well into JS, so let's just revert these comparisons to standard. This makes the behavior of the JS code match the C and Cython code for some edge cases and also hopefully makes it slightly more readable.

The added unit-tests cover these corner cases.